### PR TITLE
update default icon reference

### DIFF
--- a/templates/manifest/solution-manifest.json
+++ b/templates/manifest/solution-manifest.json
@@ -4,7 +4,7 @@
     "displayName": "resources:strings:displayName",
     "description": "resources:strings:description",
     "target": "/modules/{!company-name}.{!module-name}",
-    "icon": "sme-icon:icon-win-powerShell",
+    "icon": "sme-icon:sme-icon-powerShell",
     "keywords": [
         "resources:strings:keywords"
     ],
@@ -16,7 +16,7 @@
             "urlName": "{!primary-url-name}",
             "displayName": "resources:strings:solutionName",
             "description": "resources:strings:solutionDescription",
-            "icon": "sme-icon:icon-win-powerShell",
+            "icon": "sme-icon:sme-icon-powerShell",
             "rootNavigationBehavior": "connections",
             "connections": {
               "header": "resources:strings:connectionsListHeader",
@@ -36,7 +36,7 @@
           "urlName": "{!secondary-url-name}",
           "displayName": "resources:strings:displayName",
           "description": "resources:strings:description",
-          "icon": "sme-icon:icon-win-powerShell",
+          "icon": "sme-icon:sme-icon-powerShell",
           "path": "",
           "requirements": [
                 {

--- a/templates/manifest/tool-manifest.json
+++ b/templates/manifest/tool-manifest.json
@@ -4,7 +4,7 @@
     "displayName": "resources:strings:displayName",
     "description": "resources:strings:description",
     "target": "/modules/{!company-name}.{!module-name}",
-    "icon": "sme-icon:icon-win-powerShell",
+    "icon": "sme-icon:sme-icon-powerShell",
     "keywords": [
         "resources:strings:keywords"
     ],
@@ -15,7 +15,7 @@
           "urlName": "{!primary-url-name}",
           "displayName": "resources:strings:displayName",
           "description": "resources:strings:description",
-          "icon": "sme-icon:icon-win-powerShell",
+          "icon": "sme-icon:sme-icon-powerShell",
           "path": "",
           "requirements": [
                 {


### PR DESCRIPTION
The default PowerShell icon had a updated reference. Changed for both type of extensions that can be built.