### PR TITLE
update log message to include experimental tag and allow latest version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function createExtension() {
 		console.error('Usage: wac create --company <company-name> --name <tool-name> --version <version-tag> [--verbose]');
 		console.log('or');
 		console.log('wac create --company <company-name> --solution <solution-name> --tool <tool-name> --type <tool-type> --version <version-tag> [--verbose]');
-		console.log('Valid version tags: \'latest\', \'insider\', \'next\'');
+		console.log('Valid version tags: \'latest\', \'insider\', \'next\', \'experimential\'');
 		console.log('More information can be found here:');
 		process.exit(1);
 	}
@@ -176,7 +176,7 @@ function normalizeString(input) {
 }
 
 function isValidVersion(version) {
-	return version === 'next' || version === 'insider' || version === 'release' || version === '' || version === 'experimental';
+	return version === 'latest' || version === 'next' || version === 'insider' || version === 'release' || version === '' || version === 'experimental';
 }
 
 // this came from here: https://gist.github.com/jed/982883


### PR DESCRIPTION
Update to allow 'latest' to be put in version argument.

@mattatmsft, is release a valid version? We are checking for it in the validVersion function but not displaying it in the console log when a version is not given. 