### PR TITLE
User/alboswel/versionCheckFix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ function create(type, company, primary, secondary, version) {
 		console.log(productPath);
 		fse.mkdirSync(primary);
 
-		if (version !== 'experimental' && version !== 'next') {
+		if (version !== 'experimental' && version !== 'next' && version !== 'insider') {
 			fse.copySync(templatePath, productPath);
 		} else {
 			fse.copySync(upgradedTemplatePath, productPath);
@@ -103,12 +103,17 @@ function updateFiles(path, company, primary, secondary, version) {
 	let stringsProduct = primary.split('-').join(''); // Strings file cannot handle dashes.
 	let stringsCompany = company.split('-').join('');
 	let companyPackageIdentifier = company.split('-').join('') + primary.split('-').join('');
-
-	if (version === 'next' || version === 'insider' || version === 'experimental') {
-		let existingVersion = '"@microsoft/windows-admin-center-sdk": "latest",';
+	
+	/*
+	/ Default version is 'latest' in windows-admin-center-extension-template/package.json
+	/ Default version is 'insider' in upgrade/windows-admin-center-extension-template/package.json
+	/ Only change default versions when on 'next' or 'experimental' while two versions of template extension exist
+	*/
+	if (version === 'next' || version === 'experimental') {
+		let existingVersion = '"@microsoft/windows-admin-center-sdk": "insider",';
 		cleanDirectory[rootPackagePath] = {
 			'@{!company-name}/{!product-name}': packageName,
-			'"@microsoft/windows-admin-center-sdk": "latest",': existingVersion.replace('latest', version)
+			'"@microsoft/windows-admin-center-sdk": "insider",': existingVersion.replace('insider', version)
 		};
 	}
 	else {

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function createExtension() {
 		console.error('Usage: wac create --company <company-name> --name <tool-name> --version <version-tag> [--verbose]');
 		console.log('or');
 		console.log('wac create --company <company-name> --solution <solution-name> --tool <tool-name> --type <tool-type> --version <version-tag> [--verbose]');
-		console.log('Valid version tags: \'latest\', \'insider\', \'next\'');
+		console.log('Valid version tags: \'latest\', \'insider\', \'next\', \'experimential\'');
 		console.log('More information can be found here:');
 		process.exit(1);
 	}
@@ -176,7 +176,7 @@ function normalizeString(input) {
 }
 
 function isValidVersion(version) {
-	return version === 'next' || version === 'insider' || version === 'release' || version === '' || version === 'experimental';
+	return version === 'latest' || version === 'next' || version === 'insider' || version === 'release' || version === '' || version === 'experimental';
 }
 
 // this came from here: https://gist.github.com/jed/982883

--- a/templates/upgrade/windows-admin-center-extension-template/package.json
+++ b/templates/upgrade/windows-admin-center-extension-template/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "version": "0.1.0",
   "peerDependencies": {
-    "@microsoft/windows-admin-center-sdk": "experimental",
+    "@microsoft/windows-admin-center-sdk": "insider",
     "@angular/animations": "7.1.1",
     "@angular/common": "7.1.1",
     "@angular/compiler": "7.1.1",
@@ -33,7 +33,7 @@
     "@angular/platform-browser": "7.1.1",
     "@angular/platform-browser-dynamic": "7.1.1",
     "@angular/router": "7.1.1",
-    "@microsoft/windows-admin-center-sdk": "experimental",
+    "@microsoft/windows-admin-center-sdk": "insider",
     "@types/chart.js": "2.7.40",
     "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",


### PR DESCRIPTION
fix bug where if "next" was inputed as version it would actually set version to "experimental" in package.json. Also make the default version in the upgrade template to be "insider".