### PR TITLE
Utilities.ng to use the ng managed by npm

### DIFF
--- a/templates/windows-admin-center-extension-template/gulpfile.ts/common/utilities.ts
+++ b/templates/windows-admin-center-extension-template/gulpfile.ts/common/utilities.ts
@@ -1,6 +1,7 @@
 const values = require('yargs').argv;
 const childProcess = require('child_process');
 const log = require('fancy-log');
+const appRoot = require('app-root-path');
 
 module Utilities {
 
@@ -34,9 +35,10 @@ module Utilities {
     }
 
     export function ng(cb, args, options = {}, codeHandler = null) {
-        log('ng', args.join(' '));
+        const ng_cmd = appRoot.path + '\\node_modules\\.bin\\ng.cmd';
+        log(ng_cmd, args.join(' '));
         const errors = [];
-        const cmd = childProcess.spawn('ng.cmd', args, options);
+        const cmd = childProcess.spawn(ng_cmd, args, options);
         cmd.stdout.on('data', function (data) { log(data.toString().trim()); });
         cmd.stderr.on('data', function (data) {
             const message = data.toString().trim();

--- a/templates/windows-admin-center-extension-template/package.json
+++ b/templates/windows-admin-center-extension-template/package.json
@@ -43,6 +43,7 @@
     "@types/signalr": "2.2.35",
     "ajv": "6.4.0",
     "ansi-colors": "1.0.1",
+    "app-root-path": "^2.2.1",
     "codelyzer": "4.5.0",
     "core-js": "2.6.0",
     "gulp": "^4.0.0",


### PR DESCRIPTION
Use the intended version of ng for the commands that use Utilities.ng, by calling the ng that is installed local to the app by npm. 

