### PR TITLE
fix: make cli usable in non-windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 var fse = require('fs-extra');
 var minimist = require('minimist');
+var path = require('path');
 var pathExists = require('path-exists');
 var update = require('./update-version');
 
@@ -48,10 +49,11 @@ function createExtension() {
 }
 
 function create(type, company, primary, secondary, version) {
-	const ignoresPath = __dirname.substring(0, __dirname.length - 3) + 'templates\\ignores';
-	const legacyTemplatePath = __dirname.substring(0, __dirname.length - 3) + 'templates\\legacy\\windows-admin-center-extension-template';
-	const templatePath = __dirname.substring(0, __dirname.length - 3) + 'templates\\windows-admin-center-extension-template';
-	const manifestTemplatePath = __dirname.substring(0, __dirname.length - 3) + 'templates\\manifest';
+	const basePath = __dirname.substring(0, __dirname.length - 3);
+	const ignoresPath = path.join(basePath, "templates", "ignores");
+	const legacyTemplatePath = path.join(basePath, 'templates','legacy','windows-admin-center-extension-template');
+	const templatePath = path.join(basePath,'templates','windows-admin-center-extension-template');
+	const manifestTemplatePath = path.join(basePath,'templates','manifest');
 
 	if (pathExists.sync(primary)) {
 		console.error('This tool definition already exists.  No changes have been made.')
@@ -66,15 +68,15 @@ function create(type, company, primary, secondary, version) {
 			fse.copySync(templatePath, productPath);
 		}
 
-		fse.copyFileSync(ignoresPath + '\\git', productPath + '\\.gitignore');
-		fse.copyFileSync(ignoresPath + '\\npm', productPath + '\\.npmignore');
+		fse.copyFileSync(path.join(ignoresPath, 'git'), path.join(productPath, '.gitignore'));
+		fse.copyFileSync(path.join(ignoresPath, 'npm'), path.join(productPath, '.npmignore'));
 
 		if (type === 'tool') {
 			// make tool manifest
-			fse.copyFileSync(manifestTemplatePath + '\\tool-manifest.json', productPath + '\\src\\manifest.json');
+			fse.copyFileSync(path.join(manifestTemplatePath, 'tool-manifest.json'), path.join(productPath, 'src','manifest.json'));
 		} else if (type === 'solution') {
 			// make solution manifest
-			fse.copyFileSync(manifestTemplatePath + '\\solution-manifest.json', productPath + '\\src\\manifest.json');
+			fse.copyFileSync(path.join(manifestTemplatePath, 'solution-manifest.json'), path.join(productPath, 'src','manifest.json'));
 		}
 
 		updateFiles(company, primary, secondary, version);

--- a/src/update-version.js
+++ b/src/update-version.js
@@ -4,6 +4,7 @@ const fse = require('fs-extra');
 const { resolve } = require('path');
 const { readdir, stat } = require('fs').promises;
 const fs = require('fs');
+const path = require('path');
 
 let updateCount = 0;
 let updateSource = [];
@@ -44,26 +45,27 @@ function finalize() {
 }
 
 function copyNewFiles() {
-    let ignoresPath = __dirname.substring(0, __dirname.length - 3) + 'templates\\ignores';
-    let upgradedTemplatePath = __dirname.substring(0, __dirname.length - 3) + 'templates\\windows-admin-center-extension-template';
+    const basePath = __dirname.substring(0, __dirname.length - 3);
+    let ignoresPath = path.join(basePath, 'templates','ignores');
+    let upgradedTemplatePath = path.join(basePath, 'templates','windows-admin-center-extension-template');
 
-    fse.copyFileSync(ignoresPath + '\\git', '.\\.gitignore');
-    fse.copyFileSync(ignoresPath + '\\npm', '.\\.npmignore');
-    fse.copyFileSync(upgradedTemplatePath + '\\tslint.json', '.\\tslint.json');
-    fse.copySync(upgradedTemplatePath + '\\gulpfile.ts', '.\\gulpfile.ts');
-    fse.copyFileSync(upgradedTemplatePath + '\\tsconfig.json', '.\\tsconfig.json');
-    fse.copyFileSync(upgradedTemplatePath + '\\angular.json', '.\\angular.json');
-    fse.copyFileSync(upgradedTemplatePath + '\\tsconfig.inline.json', '.\\tsconfig.inline.json');
-    fse.copyFileSync(upgradedTemplatePath + '\\src\\tsconfig.app.json', '.\\src\\tsconfig.app.json');
-    fse.copyFileSync(upgradedTemplatePath + '\\src\\tsconfig.spec.json', '.\\src\\tsconfig.spec.json');
-    fse.copyFileSync(upgradedTemplatePath + '\\src\\polyfills.ts', '.\\src\\polyfills.ts');
+    fse.copyFileSync(path.join(ignoresPath,'git'), '.gitignore');
+    fse.copyFileSync(path.join(ignoresPath,'npm'), '.npmignore');
+    fse.copyFileSync(path.join(upgradedTemplatePath,'tslint.json'), 'tslint.json');
+    fse.copyFileSync(path.join(upgradedTemplatePath,'gulpfile.ts'), 'gulpfile.ts');
+    fse.copyFileSync(path.join(upgradedTemplatePath,'tsconfig.json'), 'tsconfig.json');
+    fse.copyFileSync(path.join(upgradedTemplatePath,'angular.json'), 'angular.json');
+    fse.copyFileSync(path.join(upgradedTemplatePath,'tsconfig.inline.json'), 'tsconfig.inline.json');
+    fse.copyFileSync(path.join(upgradedTemplatePath,'src','tsconfig.app.json'), path.join('src','tsconfig.app.json'));
+    fse.copyFileSync(path.join(upgradedTemplatePath,'src','tsconfig.spec.json'), path.join('src','tsconfig.spec.json'));
+    fse.copyFileSync(path.join(upgradedTemplatePath,'src','polyfills.ts'), path.join('src','polyfills.ts'));
 
-    if(fse.existsSync('.\\tsconfig-inline.json')) {
-        fs.unlinkSync('.\\tsconfig-inline.json');
+    if(fse.existsSync('tsconfig-inline.json')) {
+        fs.unlinkSync('tsconfig-inline.json');
     }
 
-    if(fse.existsSync('.\\package-lock.json')) {
-        fs.unlinkSync('.\\package-lock.json');
+    if(fse.existsSync('package-lock.json')) {
+        fs.unlinkSync('package-lock.json');
     }
 
     console.log('All new config and json files have been transferred.');


### PR DESCRIPTION
use `path.join()` for path concatenation.